### PR TITLE
Fixed Trigger Loci Action not allowing 'Apply' action

### DIFF
--- a/Data/InvokableGsAction.cs
+++ b/Data/InvokableGsAction.cs
@@ -119,8 +119,11 @@ public record LociDataAction : InvokableGsAction
     public LociItem LociItem { get; set; } = new LociItem();
     public LociDataAction()
     { }
-    public LociDataAction(LociDataAction other) : base(other) 
-        => LociItem = other.LociItem;
+    public LociDataAction(LociDataAction other) : base(other)
+    {
+        NewState = other.NewState;
+        LociItem = new LociItem(other.LociItem);
+    }
 
     public override bool IsValid() => LociItem.Id != Guid.Empty;
 }


### PR DESCRIPTION
LociDataAction copy constructor did not copy NewState from the editor. 

This fixes the issue that was reported is discord where selecting 'Apply' would change to 'Remove' when saving