### PR TITLE
feat: new PairRequestReceived Interaction type

### DIFF
--- a/Enums/ClientEnums/InteractionType.cs
+++ b/Enums/ClientEnums/InteractionType.cs
@@ -68,6 +68,7 @@ public enum InteractionType
 
     VisibilityChange,
     AppearanceChange,
+    PairRequestReceived,
 }
 
 public enum InteractionFilter

--- a/Enums/EnumToName.cs
+++ b/Enums/EnumToName.cs
@@ -162,6 +162,7 @@ public static class EnumToName
 
         InteractionType.VibeControl => "Vibe Control",
         InteractionType.PiShockUpdate => "Shockies Update",
+        InteractionType.PairRequestReceived => "Pairing Request",
         _ => "UNK"
     };
 


### PR DESCRIPTION
added PairRequestReceived interaction type to client enums to support pairing requests notifications

This is to support: https://github.com/Project-GagSpeak/client/pull/117