### PR TITLE
feat: add GarblerChannelChange to InteractionType enum

### DIFF
--- a/Enums/ClientEnums/InteractionType.cs
+++ b/Enums/ClientEnums/InteractionType.cs
@@ -68,6 +68,8 @@ public enum InteractionType
 
     VisibilityChange,
     AppearanceChange,
+        
+    GarblerChannelChange,
 }
 
 public enum InteractionFilter


### PR DESCRIPTION
Added an enum type to the Client InteractionType enum to support the new [garbler channel settings interaction ui](https://github.com/Project-GagSpeak/client/pull/157).